### PR TITLE
Add 'jira-juggler' as entrypoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ See help from python module:
 
 .. code::
 
-    python -m mlx.jira_juggler -h
+    jira-juggler -h
 
 .. warning::
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     platforms='any',
     packages=find_packages('src'),
     package_dir={'': 'src'},
+    entry_points={'console_scripts': ['jira-juggler = mlx.jira_juggler:entrypoint']},
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
     include_package_data=True,
     install_requires=['jira'],

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -400,7 +400,7 @@ class JiraJuggler:
                     depends_property.append_value('${now}')
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-l', '--loglevel', default=DEFAULT_LOGLEVEL,
                         help='Level for logging (strings from logging python package)')
@@ -424,3 +424,13 @@ if __name__ == "__main__":
     JUGGLER = JiraJuggler(args.url, args.username, PASSWORD, args.query, depend_on_preceding=args.depend_on_preceding)
 
     JUGGLER.juggle(args.output)
+    return 0
+
+
+def entrypoint():
+    """Wrapper function of main"""
+    raise SystemExit(main())
+
+
+if __name__ == "__main__":
+    entrypoint()

--- a/tox.ini
+++ b/tox.ini
@@ -35,12 +35,12 @@ deps =
     flake8
     readme-renderer
     twine
-skip_install = true
 commands =
     python setup.py sdist
     twine check dist/*
     check-manifest {toxinidir} -u
     flake8 src tests setup.py
+    jira-juggler -h
 
 [testenv:coveralls]
 deps =


### PR DESCRIPTION
`jira-juggler` becomes an alternative to `python3 -m mlx.jira_juggler`