### PR TITLE
Add option to sort tasks on sprints of JIRA issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     entry_points={'console_scripts': ['jira-juggler = mlx.jira_juggler:entrypoint']},
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
     include_package_data=True,
-    install_requires=['jira'],
+    install_requires=['jira', 'python-dateutil>=2.8.0,<3.*', 'natsort>=7.1.0,<8.*'],
     namespace_packages=['mlx'],
     classifiers=[
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -439,7 +439,7 @@ class JiraJuggler:
                         state = state_match.group(1)
                         prio = priorities[state]
                         if prio > task.sprint_priority:
-                            task.sprint_name = re.search("name=(.+),", sprint_info).group(1)
+                            task.sprint_name = re.search("name=(.+?),", sprint_info).group(1)
                             task.sprint_priority = prio
                             task.sprint_start_date = self.extract_start_date(sprint_info, task.issue.key)
         logging.debug("Sorting tasks based on sprint information...")
@@ -456,7 +456,7 @@ class JiraJuggler:
         Returns:
             datetime.datetime/None: Start date as a datetime object or None if the sprint does not have a start date
         """
-        start_date_match = re.search("startDate=(.+),endDate", sprint_info)
+        start_date_match = re.search("startDate=(.+?),", sprint_info)
         if start_date_match:
             start_date_str = start_date_match.group(1)
             if start_date_str != '<null>':


### PR DESCRIPTION
Added optional input argument `-s, --sort-on-sprint SPRINT_FIELD_NAME`, which sorts the tasks, i.e. JIRA issues, based on their sprint state(s) and start date. Priority from high to low: 
- active, i.e. current sprint
- future, i.e. backlog
- closed
- no sprint

When two issues have the same sprint state, the start dates of their sprints are compared. If a sprint doesn't have a start date set, it is prioritized lower. If both sprints don't have a start date set or the start dates are equal, the sprint names are taken into consideration using natural sorting and ignoring cases _(a sprint with the word 'backlog' in its name has lower priority)_.

So, the output will list tasks with the active sprint first, followed by tasks with the future sprint, and so on. This is useful if a query with `ORDER BY Rank ASC` does not return the desired order because some tickets are assigned to more than one sprint, which messes with their rank.

The value for `SPRINT_FIELD_NAME`, e.g. customfield_10851, can be extracted from the JIRA web interface by browsing to a single ticket and inspecting the input field for the Sprint field (right click on it, select Inspect, take the id of the HTML element minus the '-val' suffix).

On top of #7 