### PR TITLE
Use setuptools-scm to get version from git tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ pip-selfcheck.json
 # vim
 *.swp
 
+# Offline version file
+src/mlx/__version__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,16 +50,6 @@ notifications:
     on_failure: always
 
 deploy:
-  # test pypi
-  - provider: pypi
-    distributions: sdist
-    server: https://testpypi.python.org/pypi
-    user: SteinHeselmans
-    password:
-        secure: mGz3ih+7sFLiijlXvzRaN1pvCLHQxpx0TCS74vbytBjDNn+w0xNl/FR+ahffXOnETf2LutzJE+c74XsGSuw2QcQhtqI9+R+zc76UazArbE34bvVsxd5jp5DYFcw3k+FKnm/dHFNSGbx2oJB5rNN3S6D0X/s5+u4vo8HYsl7LW2Nbr3BzIDB8TLrJW42zxomDHT90RqaOdOjN7nDWB1PLW7UFmuAHmAwFA4CQLKaYY9acBd1xiBb16o4EbroLcbd3kZE+n3XjxafUqkTbPU7PFxNDuP3ddQrrgDYQQ0uts4JLKZtaVaRVhZvRJi9632N031523u8XBTF1+KK8LfSCeY0h1TsvdKuM48UPSaV1ev08cX4gYD4OMXgSUvk3MuUIZ+FKIkshbqENGlTfQcIxMgLLDtgrjJQ8qXVrCk28Bk22+hdMIHX+Ox2bkfaDzJx6fU0S85gYSC+veEYDeKy8Z1+8jja2ticvQcfqByGe6hWasin6qhtjZ27LNBmEJx4jdaXlxDsjmlYyAmjU1Dflyx9JlFA4w36nZJpQvtBN9LvjipO7cJ1Uzuy57DynmdtreZAorTQaCX4NkbvLkS6K4bsK1m48eiAxVPhquagtdI9S9dmvJFTCtULAdA7eLZI3zxmVKGwxbG7VStW70n+vb/UEjdUDAQVW84iOgRMrIp8=
-    on:
-      branch: master
-      tags: false
   # production pypi
   - provider: pypi
     distributions: sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,11 @@ notifications:
 deploy:
   # production pypi
   - provider: pypi
-    distributions: sdist
+    distributions: sdist bdist_wheel
     user: SteinHeselmans
     password:
         secure: mGz3ih+7sFLiijlXvzRaN1pvCLHQxpx0TCS74vbytBjDNn+w0xNl/FR+ahffXOnETf2LutzJE+c74XsGSuw2QcQhtqI9+R+zc76UazArbE34bvVsxd5jp5DYFcw3k+FKnm/dHFNSGbx2oJB5rNN3S6D0X/s5+u4vo8HYsl7LW2Nbr3BzIDB8TLrJW42zxomDHT90RqaOdOjN7nDWB1PLW7UFmuAHmAwFA4CQLKaYY9acBd1xiBb16o4EbroLcbd3kZE+n3XjxafUqkTbPU7PFxNDuP3ddQrrgDYQQ0uts4JLKZtaVaRVhZvRJi9632N031523u8XBTF1+KK8LfSCeY0h1TsvdKuM48UPSaV1ev08cX4gYD4OMXgSUvk3MuUIZ+FKIkshbqENGlTfQcIxMgLLDtgrjJQ8qXVrCk28Bk22+hdMIHX+Ox2bkfaDzJx6fU0S85gYSC+veEYDeKy8Z1+8jja2ticvQcfqByGe6hWasin6qhtjZ27LNBmEJx4jdaXlxDsjmlYyAmjU1Dflyx9JlFA4w36nZJpQvtBN9LvjipO7cJ1Uzuy57DynmdtreZAorTQaCX4NkbvLkS6K4bsK1m48eiAxVPhquagtdI9S9dmvJFTCtULAdA7eLZI3zxmVKGwxbG7VStW70n+vb/UEjdUDAQVW84iOgRMrIp8=
     on:
       branch: master
       tags: true
+      python: 3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - TOXENV=py38,codecov
     - python: '3.9'
       env:
-        - TOXENV=py39,codecov
+        - TOXENV=py39,check,codecov
 
 before_install:
   - python --version

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,8 @@ global-exclude *.py[cod] __pycache__ *.so *.dylib
 
 include NOTICE
 
+exclude src/mlx/__version__.py
+
 # added by check_manifest.py
 include *.tjp
 include Makefile

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,9 @@
-import io
 from glob import glob
-from os.path import basename, dirname, join, splitext
+from os.path import basename, splitext
 
 from setuptools import find_packages, setup
 
 PROJECT_URL = 'https://github.com/melexis/jira-juggler'
-
-
-def read(*names, **kwargs):
-    return io.open(
-        join(dirname(__file__), *names),
-        encoding=kwargs.get('encoding', 'utf8')
-    ).read()
-
 
 setup(
     name='mlx.jira_juggler',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     author_email='teh@melexis.com',
     description='A python script for extracting data from Jira, and converting to task-juggler (tj3) output',
     long_description=open("README.rst").read(),
+    long_description_content_type='text/x-rst',
     zip_safe=False,
     license='Apache License, Version 2.0',
     platforms='any',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-from glob import glob
-from os.path import basename, splitext
-
 from setuptools import find_packages, setup
 
 PROJECT_URL = 'https://github.com/melexis/jira-juggler'
@@ -22,7 +19,6 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     entry_points={'console_scripts': ['jira-juggler = mlx.jira_juggler:entrypoint']},
-    py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
     include_package_data=True,
     install_requires=['jira', 'python-dateutil>=2.8.0,<3.*', 'natsort>=7.1.0,<8.*'],
     setup_requires=['setuptools_scm'],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from os.path import basename, dirname, join, splitext
 from setuptools import find_packages, setup
 
 PROJECT_URL = 'https://github.com/melexis/jira-juggler'
-VERSION = '1.1.0'
 
 
 def read(*names, **kwargs):
@@ -17,9 +16,10 @@ def read(*names, **kwargs):
 
 setup(
     name='mlx.jira_juggler',
-    version=VERSION,
+    use_scm_version={
+        'write_to': 'src/mlx/__version__.py'
+    },
     url=PROJECT_URL,
-    download_url=PROJECT_URL + '/tarball/' + VERSION,
     author='Stein Heselmans',
     author_email='teh@melexis.com',
     description='A python script for extracting data from Jira, and converting to task-juggler (tj3) output',
@@ -33,6 +33,7 @@ setup(
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
     include_package_data=True,
     install_requires=['jira', 'python-dateutil>=2.8.0,<3.*', 'natsort>=7.1.0,<8.*'],
+    setup_requires=['setuptools_scm'],
     namespace_packages=['mlx'],
     classifiers=[
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/tests/test_jira_juggler.py
+++ b/tests/test_jira_juggler.py
@@ -8,11 +8,11 @@ import unittest
 
 try:
     from unittest.mock import MagicMock, patch, call
-except ImportError as err:
+except ImportError:
     print("unittest.mock import failed")
     try:
         from mock import MagicMock, patch, call
-    except ImportError as err:
+    except ImportError:
         print("mock import failed. installing mock")
         import pip
         pip.main(['install', 'mock'])
@@ -22,7 +22,7 @@ import mlx.jira_juggler as dut
 
 try:
     from jira import JIRA
-except ImportError as err:
+except ImportError:
     print("jira import failed")
     import pip
     pip.main(['install', 'jira'])


### PR DESCRIPTION
- Use [setuptools-scm](https://pypi.org/project/setuptools-scm/) to get version from git tag
- Run 'check' job using Python 3.9 in CI
- Only use Python 3.9 to upload package as wheel to PyPI
- Cleanup of setup.py