### PR TITLE
Support configuration of Jira endpoint and user credentials via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Jira Server
+JIRA_API_ENDPOINT=https://jira.example.com/jira
+JIRA_USERNAME=abc
+JIRA_PASSWORD=mypassword
+
+# Jira Cloud
+JIRA_API_ENDPOINT=https://example.atlassian.net
+JIRA_USERNAME=abc@example.com
+JIRA_API_TOKEN=myapitoken

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include tox.ini .travis.yml
 global-exclude *.py[cod] __pycache__ *.so *.dylib
 
 include NOTICE
+include .env.example
 
 exclude src/mlx/__version__.py
 

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ See help from python module:
 
 By default, the following endpoint for the JIRA API is used: *https://jira.melexis.com/jira*.
 The script will ask you to input your email address (or username) and API token (or password). These three
-variables can be configured by setting them in a *.env* file. This *.env* file should be located in the directory where
+variables can be configured by setting them in a *.env* file. This *.env* file shall be located in the directory where
 pip has installed the package. You can find an example configuration in *.env.example*.
 
 .. note::

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,11 @@ See help from python module:
 
     jira-juggler -h
 
+By default, the following endpoint for the JIRA API is used: *https://jira.melexis.com/jira*.
+The script will ask you to input your email address (or username) and API token (or password). These three
+variables can be configured by setting them in a *.env* file. This *.env* file should be located in the directory where
+pip has installed the package. You can find an example configuration in *.env.example*.
+
 .. note::
 
     To include resolved **and** unresolved tasks while excluding invalid tasks, you can add the following logic to the

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     package_dir={'': 'src'},
     entry_points={'console_scripts': ['jira-juggler = mlx.jira_juggler:entrypoint']},
     include_package_data=True,
-    install_requires=['jira', 'python-dateutil>=2.8.0,<3.*', 'natsort>=7.1.0,<8.*'],
+    install_requires=['jira', 'python-dateutil>=2.8.0,<3.*', 'natsort>=7.1.0,<8.*', 'python-decouple'],
     setup_requires=['setuptools_scm'],
     namespace_packages=['mlx'],
     classifiers=[

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -426,14 +426,15 @@ task {id} "{description}" {{
 class JiraJuggler:
     """Class for task-juggling Jira results"""
 
-    def __init__(self, query):
+    def __init__(self, endpoint, user, token, query):
         """Constructs a JIRA juggler object
 
         Args:
-            query (str): The Query to run on JIRA server
+            endpoint (str): Endpoint for the Jira Cloud (or Server)
+            user (str): Email address (or username)
+            token (str): API token (or password)
+            query (str): The query to run
         """
-        user, token = fetch_credentials()
-        endpoint = config('JIRA_API_ENDPOINT', default=DEFAULT_JIRA_URL)
         logging.info('Jira endpoint: %s', endpoint)
 
         self.jirahandle = JIRA(endpoint, basic_auth=(user, token))
@@ -677,7 +678,9 @@ def main():
 
     set_logging_level(args.loglevel)
 
-    JUGGLER = JiraJuggler(args.query)
+    user, token = fetch_credentials()
+    endpoint = config('JIRA_API_ENDPOINT', default=DEFAULT_JIRA_URL)
+    JUGGLER = JiraJuggler(endpoint, user, token, args.query)
 
     JUGGLER.juggle(
         output=args.output,

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -13,6 +13,7 @@ from functools import cmp_to_key
 from getpass import getpass
 
 from dateutil import parser
+from decouple import config
 from jira import JIRA, JIRAError
 from natsort import natsorted, ns
 
@@ -23,6 +24,28 @@ DEFAULT_OUTPUT = 'jira_export.tjp'
 JIRA_PAGE_SIZE = 50
 
 TAB = ' ' * 4
+
+
+def fetch_credentials():
+    """ Fetches the credentials from the .env file by default or, alternatively, from the user's input
+
+    Returns:
+        str: email address or username
+        str: API token or password
+    """
+    username = config('JIRA_USERNAME', default='')
+    api_token = config('JIRA_API_TOKEN', default='')
+    if not username:
+        username = input('JIRA email address (or username): ')
+    if not api_token:
+        password = config('JIRA_PASSWORD', default='')
+        if password:
+            logging.warning('Basic authentication with a JIRA password may be deprecated. '
+                            'Consider defining an API token as environment variable JIRA_API_TOKEN instead.')
+            return username, password
+        else:
+            api_token = getpass(f'JIRA API token (or password) for {username}: ')
+    return username, api_token
 
 
 def set_logging_level(loglevel):
@@ -403,18 +426,17 @@ task {id} "{description}" {{
 class JiraJuggler:
     """Class for task-juggling Jira results"""
 
-    def __init__(self, url, user, passwd, query):
+    def __init__(self, query):
         """Constructs a JIRA juggler object
 
         Args:
-            url (str): URL to the JIRA server
-            user (str): Username on JIRA server
-            passwd (str): Password of username on JIRA server
             query (str): The Query to run on JIRA server
         """
-        logging.info('Jira server: %s', url)
+        user, token = fetch_credentials()
+        endpoint = config('JIRA_API_ENDPOINT', default=DEFAULT_JIRA_URL)
+        logging.info('Jira endpoint: %s', endpoint)
 
-        self.jirahandle = JIRA(url, basic_auth=(user, passwd))
+        self.jirahandle = JIRA(endpoint, basic_auth=(user, token))
         logging.info('Query: %s', query)
         self.query = query
         self.issue_count = 0
@@ -636,10 +658,6 @@ def main():
     argpar = argparse.ArgumentParser()
     argpar.add_argument('-l', '--loglevel', default=DEFAULT_LOGLEVEL,
                         help='Level for logging (strings from logging python package)')
-    argpar.add_argument('-j', '--jira', dest='url', default=DEFAULT_JIRA_URL,
-                        help='URL to JIRA server')
-    argpar.add_argument('-u', '--username', required=True,
-                        help='Your username on JIRA server')
     argpar.add_argument('-q', '--query', required=True,
                         help='Query to perform on JIRA server')
     argpar.add_argument('-o', '--output', default=DEFAULT_OUTPUT,
@@ -659,9 +677,7 @@ def main():
 
     set_logging_level(args.loglevel)
 
-    PASSWORD = getpass('Enter JIRA password for {user}: '.format(user=args.username))
-
-    JUGGLER = JiraJuggler(args.url, args.username, PASSWORD, args.query)
+    JUGGLER = JiraJuggler(args.query)
 
     JUGGLER.juggle(
         output=args.output,


### PR DESCRIPTION
Instead of always prompting the user to input their password or API token via the CLI, this PR will allow users to configure their Jira Cloud (or server) endpoint, their email address (or username) and their API token (or password) via environment variables or in [a special text file](https://pypi.org/project/python-decouple/#where-is-the-settings-data-stored).

The following input arguments have been **removed** for sake of simplicity and alignment with our other tools:

- `-j, --jira`
- `-u, --username`