### PR TITLE
Fix end date of approved Change Requests and issues with multiple transitions to Approved/Resolved

### DIFF
--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime, time
 from functools import cmp_to_key
 from getpass import getpass
+from operator import attrgetter
 
 from dateutil import parser
 from decouple import config
@@ -351,6 +352,7 @@ task {id} "{description}" {{
         self.summary = self.DEFAULT_SUMMARY
         self.properties = {}
         self.issue = None
+        self._resolved_at_date = None
 
         if jira_issue:
             self.load_from_jira_issue(jira_issue)
@@ -368,6 +370,8 @@ task {id} "{description}" {{
         self.properties['allocate'] = JugglerTaskAllocate(jira_issue)
         self.properties['effort'] = JugglerTaskEffort(jira_issue)
         self.properties['depends'] = JugglerTaskDepends(jira_issue)
+        if self.is_resolved:
+            self.resolved_at_date = self.determine_resolved_at_date()
 
     def validate(self, tasks):
         """Validates (and corrects) the current task
@@ -412,16 +416,27 @@ task {id} "{description}" {{
 
     @property
     def resolved_at_date(self):
-        """datetime.datetime: Date and time corresponding to the last transition to the Resolved status; None when not
-            resolved
+        """datetime.datetime: Date and time corresponding to the last transition to the Approved/Resolved status; the
+            transition to the Closed status is used as fallback; None when not resolved
         """
-        if self.is_resolved:
-            for change in self.issue.changelog.histories:
-                for item in change.items[::-1]:
-                    if item.field.lower() == 'status' and item.toString.lower() in ('resolved', 'closed'):
-                        return parser.isoparse(change.created)
-        return None
+        return self._resolved_at_date
 
+
+    @resolved_at_date.setter
+    def resolved_at_date(self, value):
+        self._resolved_at_date = value
+
+    def determine_resolved_at_date(self):
+        closed_at_date = None
+        for change in sorted(self.issue.changelog.histories, key=attrgetter('created'), reverse=True):
+            for item in change.items:
+                if item.field.lower() == 'status':
+                    status = item.toString.lower()
+                    if status in ('approved', 'resolved'):
+                        return parser.isoparse(change.created)
+                    elif status in ('closed',) and closed_at_date is None:
+                        closed_at_date = parser.isoparse(change.created)
+        return closed_at_date
 
 class JiraJuggler:
     """Class for task-juggling Jira results"""

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -421,7 +421,6 @@ task {id} "{description}" {{
         """
         return self._resolved_at_date
 
-
     @resolved_at_date.setter
     def resolved_at_date(self, value):
         self._resolved_at_date = value
@@ -437,6 +436,7 @@ task {id} "{description}" {{
                     elif status in ('closed',) and closed_at_date is None:
                         closed_at_date = parser.isoparse(change.created)
         return closed_at_date
+
 
 class JiraJuggler:
     """Class for task-juggling Jira results"""
@@ -492,7 +492,6 @@ class JiraJuggler:
                 busy = False
 
             self.issue_count += len(issues)
-
             for issue in issues:
                 logging.debug('Retrieved %s: %s', issue.key, issue.fields.summary)
                 tasks.append(JugglerTask(issue))

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -188,8 +188,8 @@ class JugglerTaskAllocate(JugglerTaskProperty):
                             self.value = getattr(item, 'from', None)
                         else:
                             self.value = item.to
-                            return  # got last assignee before transition to Resolved status
-                    elif item.field.lower() == 'status' and item.toString.lower() == 'resolved':
+                            return  # got last assignee before transition to Approved/Resolved status
+                    elif item.field.lower() == 'status' and item.toString.lower() in ('approved', 'resolved'):
                         before_resolved = True
                         if self.value and self.value != self.DEFAULT_VALUE:
                             return  # assignee was changed after transition to Resolved status
@@ -397,8 +397,8 @@ task {id} "{description}" {{
 
     @property
     def is_resolved(self):
-        """bool: True if JIRA issue has been resolved; False otherwise"""
-        return self.issue is not None and self.issue.fields.status.name in ('Closed', 'Resolved')
+        """bool: True if JIRA issue has been approved/resolved/closed; False otherwise"""
+        return self.issue is not None and self.issue.fields.status.name in ('Approved', 'Resolved', 'Closed')
 
     @property
     def resolved_at_repr(self):

--- a/tests/test_jira_juggler.py
+++ b/tests/test_jira_juggler.py
@@ -299,7 +299,8 @@ class TestJiraJuggler(unittest.TestCase):
 
     @patch('mlx.jira_juggler.JIRA', autospec=True)
     def test_resolved_task(self, jira_mock):
-        '''Test that the last assignee in the Analyzed state is used and the Time Spent is used as effort'''
+        '''Test that the last assignee in the Analyzed state is used and the Time Spent is used as effort
+        Test that the most recent transition to the Approved/Resolved state is used to mark the end'''
         jira_mock_object = MagicMock(spec=JIRA)
         jira_mock.return_value = jira_mock_object
         juggler = dut.JiraJuggler(self.URL, self.USER, self.PASSWD, self.QUERY)
@@ -343,7 +344,7 @@ class TestJiraJuggler(unittest.TestCase):
             {
                 'items': [{
                     'field': 'status',
-                    'toString': 'Resolved',
+                    'toString': 'Approved',
                 }],
                 'created': '2022-05-25T14:07:11.974+0200',
             },
@@ -361,6 +362,7 @@ class TestJiraJuggler(unittest.TestCase):
         self.assertEqual(1, len(issues))
         self.assertEqual(self.ASSIGNEE2, issues[0].properties['allocate'].value)
         self.assertEqual(self.ESTIMATE2 / self.SECS_PER_DAY, issues[0].properties['effort'].value)
+        self.assertEqual('2022-05-25 14:07:11.974000+02:00', str(issues[0].resolved_at_date))
 
     @patch('mlx.jira_juggler.JIRA', autospec=True)
     def test_closed_task(self, jira_mock):

--- a/tests/test_jira_juggler.py
+++ b/tests/test_jira_juggler.py
@@ -308,41 +308,46 @@ class TestJiraJuggler(unittest.TestCase):
                 'items': [{
                     'field': 'assignee',
                     'to': self.ASSIGNEE1,
-                }]
+                }],
+                'created': '2022-04-08T13:11:47.749+0200',
             },
             {
                 'items': [{
                     'field': 'status',
                     'toString': 'Resolved',
-                }]
+                }],
+                'created': '2022-04-11T08:13:14.350+0200',
             },
             {
                 'items': [{
                     'field': 'assignee',
                     'to': self.ASSIGNEE3,
                     # 'from': self.ASSIGNEE1,  # cannot use 'from' as key to test
-                }]
+                }],
+                'created': '2022-04-12T13:04:11.449+0200',
             },
             {
                 'items': [{
                     'field': 'status',
                     'toString': 'Analyzed',
-                }]
+                }],
+                'created': '2022-04-13T14:10:43.632+0200',
             },
             {
                 'items': [{
                     'field': 'assignee',
                     'to': self.ASSIGNEE2,
-                }]
+                }],
+                'created': '2022-05-02T09:20:36.310+0200',
             },
             {
                 'items': [{
                     'field': 'status',
                     'toString': 'Resolved',
-                }]
+                }],
+                'created': '2022-05-25T14:07:11.974+0200',
             },
         ]
-
         jira_mock_object.search_issues.side_effect = [[self._mock_jira_issue(self.KEY1,
                                                                              self.SUMMARY1,
                                                                              self.ASSIGNEE1,
@@ -371,13 +376,15 @@ class TestJiraJuggler(unittest.TestCase):
                 'items': [{
                     'field': 'status',
                     'toString': 'Resolved',
-                }]
+                }],
+                'created': '2022-04-12T13:04:11.449+0200',
             },
             {
                 'items': [{
                     'field': 'assignee',
                     'to': self.ASSIGNEE2,
-                }]
+                }],
+                'created': '2022-05-25T14:07:11.974+0200',
             },
         ]
 


### PR DESCRIPTION
1. The transition of a Change Request from the Analyzed status to the Approved status will now be used to mark the end of the Change Request instead of the transition to the Closed status, bug implemented in #18. This is analogous to the transition of a Task from Analyzed to Resolved.

2. When a Jira issue is moved from Analyzed to Approved/Resolved more than once, jira-juggler took the oldest transition instead of the most recent transition to Approved/Resolved. This PR fixes that bug.