### PR TITLE
Prevent an unresolved task from starting right after its Jira dependency

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
     :target: http://www.apache.org/licenses/LICENSE-2.0
 
 =============================
-JIRA to TaskJuggler convertor
+JIRA to TaskJuggler Convertor
 =============================
 
 Tool for converting a set of JIRA tasks to TaskJuggler (TJ3) syntax.
@@ -18,11 +18,11 @@ module can convert the JIRA tasks to a gantt chart using the `TaskJuggler <http:
 Installation
 ------------
 
-Installation from pypi:
+Installation from PyPI:
 
 .. code::
 
-    pip install mlx.jira_juggler
+    pip install mlx.jira-juggler
 
 -----
 Usage

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     keywords=[
         'Jira',

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -528,7 +528,7 @@ class JiraJuggler:
         if not juggler_tasks:
             return None
         if output:
-            with open(output, 'w') as out:
+            with open(output, 'w', encoding='utf-8') as out:
                 for task in juggler_tasks:
                     out.write(str(task))
         return juggler_tasks

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -113,6 +113,14 @@ def calculate_weekends(date, workdays_passed, weeklymax):
 
 
 def to_username(value):
+    """Converts the given value to a username (user ID), if needed, while caching the result.
+
+    Args:
+        value (str/jira.User): String (account ID or user ID) or User instance
+
+    Returns:
+        str: The corresponding username
+    """
     user_id = value.accountId if hasattr(value, 'accountId') else value
     if user_id in id_to_username_mapping:
         return id_to_username_mapping[user_id]
@@ -126,6 +134,17 @@ def to_username(value):
 
 
 def determine_username(user):
+    """Determines the username (user ID) for the given User.
+
+    Args:
+        user (jira.User): User instance
+
+    Returns
+        str: Corresponding username
+
+    Raises:
+        Exception: Failed to determine username
+    """
     if hasattr(user, 'emailAddress'):
         username = user.emailAddress.split('@')[0]
     elif hasattr(user, 'name'):  # compatibility with Jira Server

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -218,8 +218,15 @@ class JugglerTaskAllocate(JugglerTaskProperty):
             if getattr(jira_issue.fields, 'assignee', None):
                 if hasattr(jira_issue.fields.assignee, 'name'):
                     self.value = jira_issue.fields.assignee.name
-                else:
+                elif hasattr(jira_issue.fields.assignee, 'emailAddress'):
                     self.value = jira_issue.fields.assignee.emailAddress.split('@')[0]
+                elif hasattr(jira_issue.fields.assignee, 'displayName'):
+                    full_name = jira_issue.fields.assignee.displayName
+                    self.value = f'"{full_name}"'
+                    logging.error(f"Failed to fetch email address of {full_name!r}: they restricted its visibility; "
+                                  f"using identifier {self.value!r} as fallback value.")
+                else:
+                    raise Exception(f"Failed to determine assignee for task {jira_issue.key}")
             else:
                 self.value = self.DEFAULT_VALUE
 

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -243,7 +243,9 @@ class JugglerTaskAllocate(JugglerTaskProperty):
                 for item in change.items:
                     if item.field.lower() == 'assignee':
                         if not before_resolved:
-                            self.value = to_username(getattr(item, 'from', None))
+                            self.value = getattr(item, 'from', None)
+                            if self.value:
+                                self.value = to_username(self.value)
                         else:
                             self.value = to_username(item.to)
                             return  # got last assignee before transition to Approved/Resolved status

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -7,7 +7,7 @@ This script queries Jira, and generates a task-juggler input file to generate a 
 import argparse
 import logging
 import re
-from abc import ABC, abstractmethod
+from abc import ABC
 from datetime import datetime, time
 from functools import cmp_to_key
 from getpass import getpass

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -144,7 +144,16 @@ class JugglerTaskProperty(ABC):
         if jira_issue:
             self.load_from_jira_issue(jira_issue)
 
-    @abstractmethod
+    @property
+    def is_empty(self):
+        """bool: True if the property contains an empty or uninitialized value"""
+        return not self.value or self.value == self.DEFAULT_VALUE
+
+    def clear(self):
+        """Sets the name and value to the default"""
+        self.name = self.DEFAULT_NAME
+        self.value = self.DEFAULT_VALUE
+
     def load_from_jira_issue(self, jira_issue):
         """Loads the object with data from a Jira issue
 
@@ -205,7 +214,7 @@ class JugglerTaskAllocate(JugglerTaskProperty):
                         if self.value and self.value != self.DEFAULT_VALUE:
                             return  # assignee was changed after transition to Closed/Resolved status
 
-        if not self.value or self.value == self.DEFAULT_VALUE:
+        if self.is_empty:
             if getattr(jira_issue.fields, 'assignee', None):
                 if hasattr(jira_issue.fields.assignee, 'name'):
                     self.value = jira_issue.fields.assignee.name
@@ -345,6 +354,31 @@ class JugglerTaskDepends(JugglerTaskProperty):
         return ''
 
 
+class JugglerTaskTime(JugglerTaskProperty):
+    """Class for setting the start/end time of a juggler task"""
+
+    DEFAULT_VALUE = ''
+    PREFIX = ''
+
+    def validate(self, *_):
+        """Validates the current task property"""
+        if not self.is_empty:
+            valid_names = ('start', 'end')
+            if self.name not in valid_names:
+                raise ValueError(f'The name of {self.__class__.__name__} is invalid; expected a value in {valid_names}')
+
+    def __str__(self):
+        """Converts task property object to the task juggler syntax
+
+        Returns:
+            str: String representation of the task property in juggler syntax
+        """
+        if self.value:
+            return self.TEMPLATE.format(prop=self.name,
+                                        value=self.value)
+        return ''
+
+
 class JugglerTask:
     """Class for a task for Task-Juggler"""
 
@@ -385,6 +419,7 @@ task {id} "{description}" {{
         self.properties['allocate'] = JugglerTaskAllocate(jira_issue)
         self.properties['effort'] = JugglerTaskEffort(jira_issue)
         self.properties['depends'] = JugglerTaskDepends(jira_issue)
+        self.properties['time'] = JugglerTaskTime()
 
     def validate(self, tasks):
         """Validates (and corrects) the current task
@@ -551,34 +586,34 @@ class JiraJuggler:
             weeklymax (float): Number of allocated workdays per week
             current_date (datetime.datetime): Offset-naive datetime to treat as the current date
         """
+        current_date_str = to_juggler_date(current_date)
         unresolved_tasks = {}
         for task in tasks:
             assignee = str(task.properties['allocate'])
-            if assignee not in unresolved_tasks:
-                unresolved_tasks[assignee] = []
 
             depends_property = task.properties['depends']
+            time_property = task.properties['time']
+
             if task.is_resolved:
-                depends_property.PREFIX = ''
-                depends_property.name = 'end'
-                depends_property.value = [task.resolved_at_repr]  # overwrite any links in JIRA
+                depends_property.clear()  # don't output any links in JIRA
+                time_property.name = 'end'
+                time_property.value = task.resolved_at_repr
             else:
-                if unresolved_tasks[assignee]:  # task with dependency
+                if assignee in unresolved_tasks:  # link to a preceding unresolved task
                     preceding_task = unresolved_tasks[assignee][-1]
                     depends_property.append_value(to_identifier(preceding_task.key))
-                elif not depends_property.value:  # first unresolved task for assignee
-                    depends_property.PREFIX = ''
-                    depends_property.name = 'start'
-                    val = to_juggler_date(current_date)
+                else:  # first unresolved task for assignee: set start time
+                    start_time = current_date_str
                     if task.issue.fields.timespent:
                         effort_property = task.properties['effort']
                         effort_property.value += task.issue.fields.timespent / JugglerTaskEffort.FACTOR
                         days_spent = task.issue.fields.timespent // 3600 / 8
                         weekends = calculate_weekends(current_date, days_spent, weeklymax)
                         days_per_weekend = min(2, 7 - weeklymax)
-                        val = f"%{{{val} - {days_spent + weekends * days_per_weekend}d}}"
-                    depends_property.append_value(val)
-                unresolved_tasks[assignee].append(task)
+                        start_time = f"%{{{start_time} - {days_spent + weekends * days_per_weekend}d}}"
+                    time_property.name = 'start'
+                    time_property.value = start_time
+                unresolved_tasks.setdefault(assignee, []).append(task)
 
     def sort_tasks_on_sprint(self, tasks, sprint_field_name):
         """Sorts given list of tasks based on the values of the field with the given name.

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -591,9 +591,9 @@ class JiraJuggler:
         If the task has been resolved, 'end' is added instead of 'depends' no matter what, followed by the
         date and time on which it's been resolved.
 
-        If it's the first unresolved task for a given assignee and it's not linked with 'depends on'/'is blocked by'
-        through JIRA, 'start' is added instead followed by the date and hour on which the task has been started,
-        i.e. current time minus time spent. For the other unresolved tasks, the effort estimate is 'Remaining' time
+        If it's the first unresolved task for a given assignee, 'start' is added followed by the date and hour on which
+        the task has been started, i.e. current time minus time spent.
+        For the other unresolved tasks, the effort estimate is 'Remaining' time
         only instead of 'Remaining + Logged' time since parallellism is not supported by
         TaskJuggler and this approach results in a more accurate forecast.
 

--- a/tests/test_jira_juggler.py
+++ b/tests/test_jira_juggler.py
@@ -464,6 +464,7 @@ class TestJiraJuggler(unittest.TestCase):
         self.assertEqual(f'    depends !{self.KEY1}, !{self.KEY2}\n', str(issues[2].properties['depends']))
 
         self.assertEqual('', str(issues[3].properties['depends']))
+        self.assertEqual('    start 2021-08-23-13:00\n', str(issues[3].properties['time']))  # start on current date
 
     def _mock_jira_issue(self, key, summary, assignee=None, estimates=[], depends=[], histories=[], status="Open"):
         '''

--- a/tests/test_jira_juggler.py
+++ b/tests/test_jira_juggler.py
@@ -210,9 +210,6 @@ class TestJiraJuggler(unittest.TestCase):
                                              self.DEPENDS1,
                                              email=self.EMAIL1)
         mocked_issue.fields.assignee.emailAddress = ''
-        from pprint import pprint
-        pprint(mocked_issue.fields)
-        #raise ValueError(mocked_issue.fields.assignee.emailAddress)
         jira_mock_object.search_issues.side_effect = [[mocked_issue], []]
         issues = juggler.juggle()
         jira_mock_object.search_issues.assert_has_calls([call(self.QUERY, maxResults=dut.JIRA_PAGE_SIZE, startAt=0, expand='changelog'),

--- a/tests/test_jira_juggler.py
+++ b/tests/test_jira_juggler.py
@@ -445,11 +445,12 @@ class TestJiraJuggler(unittest.TestCase):
         self.assertEqual(3, len(issues))
         self.assertEqual(self.ASSIGNEE1, issues[0].properties['allocate'].value)
         self.assertEqual(self.ESTIMATE1 / self.SECS_PER_DAY, issues[0].properties['effort'].value)
-        self.assertEqual('    end 2021-08-18-18:00-+0200\n', str(issues[0].properties['depends']))
+        self.assertEqual('    end 2021-08-18-18:00-+0200\n', str(issues[0].properties['time']))
+        self.assertEqual('', str(issues[0].properties['depends']))
 
         self.assertEqual(self.ASSIGNEE1, issues[1].properties['allocate'].value)
         self.assertEqual(3.2 + 2.4, issues[1].properties['effort'].value)
-        self.assertEqual('    start %{2021-08-23-13:00 - 9.125d}\n', str(issues[1].properties['depends']))  # 3.2 days spent
+        self.assertEqual('    start %{2021-08-23-13:00 - 9.125d}\n', str(issues[1].properties['time']))  # 3.2 days spent
 
         self.assertEqual(self.ASSIGNEE1, issues[2].properties['allocate'].value)
         self.assertEqual(self.ESTIMATE3 / self.SECS_PER_DAY, issues[2].properties['effort'].value)

--- a/tests/test_jira_juggler.py
+++ b/tests/test_jira_juggler.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import json
-from collections import namedtuple
 from datetime import datetime
+from types import SimpleNamespace
 
 from dateutil import parser
 from parameterized import parameterized
@@ -51,24 +51,37 @@ class TestJiraJuggler(unittest.TestCase):
     KEY1 = 'Issue1'
     SUMMARY1 = 'Some random description of issue 1'
     ASSIGNEE1 = 'John Doe'
+    EMAIL1 = 'jod@gmail.com'
+    USERNAME1 = 'jod'
     ESTIMATE1 = 0.3 * SECS_PER_DAY
     DEPENDS1 = []
 
     KEY2 = 'Issue2'
     SUMMARY2 = 'Some random description of issue 2'
     ASSIGNEE2 = 'Jane Doe'
+    EMAIL2 = 'jad@gmail.com'
+    USERNAME2 = 'jad'
     ESTIMATE2 = 1.2 * SECS_PER_DAY
     DEPENDS2 = [KEY1]
 
     KEY3 = 'Issue3'
     SUMMARY3 = 'Some random description of issue 3'
     ASSIGNEE3 = 'Cooky Doe'
+    EMAIL3 = 'cod@gmail.com'
+    USERNAME3 = 'cod'
     ESTIMATE3 = 1.0 * SECS_PER_DAY
     DEPENDS3 = [KEY1, KEY2]
 
     JIRA_JSON_ASSIGNEE_TEMPLATE = '''
             "assignee": {{
                 "name": "{assignee}"
+            }}
+    '''
+    JIRA_CLOUD_JSON_ASSIGNEE_TEMPLATE = '''
+            "assignee": {{
+                "emailAddress": "{email}",
+                "displayName": "{assignee}",
+                "accountId": "{account_id}"
             }}
     '''
 
@@ -135,7 +148,7 @@ class TestJiraJuggler(unittest.TestCase):
 
     @patch('mlx.jira_juggler.JIRA', autospec=True)
     def test_single_task_happy(self, jira_mock):
-        '''Test for simple happy flow: single task is returned by Jira'''
+        '''Test for simple happy flow: single task is returned by Jira Server'''
         jira_mock_object = MagicMock(spec=JIRA)
         jira_mock.return_value = jira_mock_object
         juggler = dut.JiraJuggler(self.URL, self.USER, self.PASSWD, self.QUERY)
@@ -154,6 +167,60 @@ class TestJiraJuggler(unittest.TestCase):
         self.assertEqual(self.KEY1, issues[0].key)
         self.assertEqual(self.SUMMARY1, issues[0].summary)
         self.assertEqual(self.ASSIGNEE1, issues[0].properties['allocate'].value)
+        self.assertEqual(self.ESTIMATE1 / self.SECS_PER_DAY, issues[0].properties['effort'].value)
+        self.assertEqual(self.DEPENDS1, issues[0].properties['depends'].value)
+
+    @patch('mlx.jira_juggler.JIRA', autospec=True)
+    def test_single_task_email_happy(self, jira_mock):
+        '''Test for simple happy flow: single task is returned by Jira Cloud'''
+        jira_mock_object = MagicMock(spec=JIRA)
+        jira_mock.return_value = jira_mock_object
+        juggler = dut.JiraJuggler(self.URL, self.USER, self.PASSWD, self.QUERY)
+        self.assertEqual(self.QUERY, juggler.query)
+
+        jira_mock_object.search_issues.side_effect = [[self._mock_jira_issue(self.KEY1,
+                                                                             self.SUMMARY1,
+                                                                             self.ASSIGNEE1,
+                                                                             [self.ESTIMATE1, None, None],
+                                                                             self.DEPENDS1,
+                                                                             email=self.EMAIL1)
+                                                       ], []]
+        issues = juggler.juggle()
+        jira_mock_object.search_issues.assert_has_calls([call(self.QUERY, maxResults=dut.JIRA_PAGE_SIZE, startAt=0, expand='changelog'),
+                                                         call(self.QUERY, maxResults=dut.JIRA_PAGE_SIZE, startAt=1, expand='changelog')])
+        self.assertEqual(1, len(issues))
+        self.assertEqual(self.KEY1, issues[0].key)
+        self.assertEqual(self.SUMMARY1, issues[0].summary)
+        self.assertEqual(self.USERNAME1, issues[0].properties['allocate'].value)
+        self.assertEqual(self.ESTIMATE1 / self.SECS_PER_DAY, issues[0].properties['effort'].value)
+        self.assertEqual(self.DEPENDS1, issues[0].properties['depends'].value)
+
+    @patch('mlx.jira_juggler.JIRA', autospec=True)
+    def test_single_task_email_hidden(self, jira_mock):
+        '''Test for error logging when user has restricted email visibility in Jira Cloud'''
+        jira_mock_object = MagicMock(spec=JIRA)
+        jira_mock.return_value = jira_mock_object
+        juggler = dut.JiraJuggler(self.URL, self.USER, self.PASSWD, self.QUERY)
+        self.assertEqual(self.QUERY, juggler.query)
+
+        mocked_issue = self._mock_jira_issue(self.KEY1,
+                                             self.SUMMARY1,
+                                             self.ASSIGNEE1,
+                                             [self.ESTIMATE1, None, None],
+                                             self.DEPENDS1,
+                                             email=self.EMAIL1)
+        mocked_issue.fields.assignee.emailAddress = ''
+        from pprint import pprint
+        pprint(mocked_issue.fields)
+        #raise ValueError(mocked_issue.fields.assignee.emailAddress)
+        jira_mock_object.search_issues.side_effect = [[mocked_issue], []]
+        issues = juggler.juggle()
+        jira_mock_object.search_issues.assert_has_calls([call(self.QUERY, maxResults=dut.JIRA_PAGE_SIZE, startAt=0, expand='changelog'),
+                                                         call(self.QUERY, maxResults=dut.JIRA_PAGE_SIZE, startAt=1, expand='changelog')])
+        self.assertEqual(1, len(issues))
+        self.assertEqual(self.KEY1, issues[0].key)
+        self.assertEqual(self.SUMMARY1, issues[0].summary)
+        self.assertEqual(f'"{self.ASSIGNEE1}"', issues[0].properties['allocate'].value)
         self.assertEqual(self.ESTIMATE1 / self.SECS_PER_DAY, issues[0].properties['effort'].value)
         self.assertEqual(self.DEPENDS1, issues[0].properties['depends'].value)
 
@@ -466,7 +533,7 @@ class TestJiraJuggler(unittest.TestCase):
         self.assertEqual('', str(issues[3].properties['depends']))
         self.assertEqual('    start 2021-08-23-13:00\n', str(issues[3].properties['time']))  # start on current date
 
-    def _mock_jira_issue(self, key, summary, assignee=None, estimates=[], depends=[], histories=[], status="Open"):
+    def _mock_jira_issue(self, key, summary, assignee='', estimates=[], depends=[], histories=[], status="Open", email=''):
         '''
         Helper function to create a mocked Jira issue
 
@@ -484,7 +551,11 @@ class TestJiraJuggler(unittest.TestCase):
         props = ', ' + self.JIRA_JSON_STATUS_TEMPLATE.format(status=status)
         if assignee:
             props += ', '
-            props += self.JIRA_JSON_ASSIGNEE_TEMPLATE.format(assignee=assignee)
+            if email:
+                props += self.JIRA_CLOUD_JSON_ASSIGNEE_TEMPLATE.format(email=email, assignee=assignee,
+                                                                       account_id=id(email))
+            else:
+                props += self.JIRA_JSON_ASSIGNEE_TEMPLATE.format(assignee=assignee)
         if estimates:
             estimates = ['null' if val is None else val for val in estimates]
             props += ', '
@@ -504,7 +575,7 @@ class TestJiraJuggler(unittest.TestCase):
                                                     summary=summary,
                                                     properties=props,
                                                     changelog=changelog)
-        return json.loads(data, object_hook=lambda d: namedtuple('X', d.keys())(*d.values()))
+        return json.loads(data, object_hook=lambda d: SimpleNamespace(**d))
 
     @parameterized.expand([
         ("2021-08-15-11:00", 10, 5, 2),

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36, py37, py38, py39,
+    py36, py37, py38, py39, py310, py3.11
     clean,
     check,
 
@@ -10,6 +10,8 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
+    3.11: py311
 
 [testenv]
 basepython =
@@ -19,6 +21,8 @@ basepython =
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
     py39: {env:TOXPYTHON:python3.9}
+    py310: {env:TOXPYTHON:python3.10}
+    py311: {env:TOXPYTHON:python3.11}
     {clean,check,report,coveralls,codecov}: python3
 setenv =
     PYTHONPATH={toxinidir}/tests
@@ -28,7 +32,6 @@ passenv =
 usedevelop = false
 deps =
     pytest
-    pytest-travis-fold
     pytest-cov
     mock
     pip>=20.3.4


### PR DESCRIPTION
- Prevent an unresolved task from starting right after its Jira dependency 
- Log error and use display name in case the visibility of a user's email address has been restricted

Resolves #23 