### PR TITLE
Require a minimum version of the jira package

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     include_package_data=True,
     install_requires=['jira>=3.1.1', 'python-dateutil>=2.8.0,<3.0', 'natsort>=7.1.0,<8.0', 'python-decouple'],
     setup_requires=['setuptools-scm>=6.0.0,<8.0'],
+    python_requires='>=3.7',
     namespace_packages=['mlx'],
     classifiers=[
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -32,7 +33,6 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(
     package_dir={'': 'src'},
     entry_points={'console_scripts': ['jira-juggler = mlx.jira_juggler:entrypoint']},
     include_package_data=True,
-    install_requires=['jira>=3.1.1', 'python-dateutil>=2.8.0,<3.*', 'natsort>=7.1.0,<8.*', 'python-decouple'],
-    setup_requires=['setuptools-scm>=6.0.0,<7.*'],
+    install_requires=['jira>=3.1.1', 'python-dateutil>=2.8.0,<3.0', 'natsort>=7.1.0,<8.0', 'python-decouple'],
+    setup_requires=['setuptools-scm>=6.0.0,<7.0'],
     namespace_packages=['mlx'],
     classifiers=[
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     entry_points={'console_scripts': ['jira-juggler = mlx.jira_juggler:entrypoint']},
     include_package_data=True,
     install_requires=['jira>=3.1.1', 'python-dateutil>=2.8.0,<3.0', 'natsort>=7.1.0,<8.0', 'python-decouple'],
-    setup_requires=['setuptools-scm>=6.0.0,<7.0'],
+    setup_requires=['setuptools-scm>=6.0.0,<8.0'],
     namespace_packages=['mlx'],
     classifiers=[
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     package_dir={'': 'src'},
     entry_points={'console_scripts': ['jira-juggler = mlx.jira_juggler:entrypoint']},
     include_package_data=True,
-    install_requires=['jira', 'python-dateutil>=2.8.0,<3.*', 'natsort>=7.1.0,<8.*', 'python-decouple'],
+    install_requires=['jira>=3.1.1', 'python-dateutil>=2.8.0,<3.*', 'natsort>=7.1.0,<8.*', 'python-decouple'],
     setup_requires=['setuptools-scm>=6.0.0,<7.*'],
     namespace_packages=['mlx'],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
-    py36, py37, py38, py39, py310, py3.11
+    py37, py38, py39, py310, py3.11
     clean,
     check,
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
@@ -17,7 +16,6 @@ python =
 basepython =
     py: python3
     pypy: {env:TOXPYTHON:pypy}
-    py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
     py39: {env:TOXPYTHON:python3.9}


### PR DESCRIPTION
Require a minimum version of the jira package, which supports Jira Cloud.

Addresses a crash:

```
raise JIRAError(
jira.exceptions.JIRAError: JiraError HTTP 400 url: https://melexis.atlassian.net/rest/api/2/user?username=<<my_account_id>>
text: The 'accountId' query parameter needs to be provided

```