### PR TITLE
Fix crash introduced in #25

### DIFF
--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -624,7 +624,7 @@ class JiraJuggler:
             weeklymax (float): Number of allocated workdays per week
             current_date (datetime.datetime): Offset-naive datetime to treat as the current date
         """
-        key_to_task_map = {task.key: task for task in tasks}
+        id_to_task_map = {to_identifier(task.key): task for task in tasks}
         current_date_str = to_juggler_date(current_date)
         unresolved_tasks = {}
         for task in tasks:
@@ -642,8 +642,8 @@ class JiraJuggler:
                     preceding_task = unresolved_tasks[assignee][-1]
                     depends_property.append_value(to_identifier(preceding_task.key))
                 else:  # first unresolved task for assignee: set start time unless it depends on an unresolved task
-                    for key in depends_property.value:
-                        if not key_to_task_map[key].is_resolved:
+                    for identifier in depends_property.value:
+                        if not id_to_task_map[identifier].is_resolved:
                             break
                     else:
                         start_time = current_date_str

--- a/tests/test_jira_juggler.py
+++ b/tests/test_jira_juggler.py
@@ -48,7 +48,8 @@ class TestJiraJuggler(unittest.TestCase):
     QUERY = 'some random query'
     SECS_PER_DAY = 8.0 * 60 * 60
 
-    KEY1 = 'Issue1'
+    KEY1 = 'Issue-1'
+    ID1 = 'Issue_1'
     SUMMARY1 = 'Some random description of issue 1'
     ASSIGNEE1 = 'John Doe'
     EMAIL1 = 'jod@gmail.com'
@@ -56,21 +57,23 @@ class TestJiraJuggler(unittest.TestCase):
     ESTIMATE1 = 0.3 * SECS_PER_DAY
     DEPENDS1 = []
 
-    KEY2 = 'Issue2'
+    KEY2 = 'Issue-2'
+    ID2 = 'Issue_2'
     SUMMARY2 = 'Some random description of issue 2'
     ASSIGNEE2 = 'Jane Doe'
     EMAIL2 = 'jad@gmail.com'
     USERNAME2 = 'jad'
     ESTIMATE2 = 1.2 * SECS_PER_DAY
-    DEPENDS2 = [KEY1]
+    DEPENDS2 = [ID1]
 
-    KEY3 = 'Issue3'
+    KEY3 = 'Issue-3'
+    ID3 = 'Issue_3'
     SUMMARY3 = 'Some random description of issue 3'
     ASSIGNEE3 = 'Cooky Doe'
     EMAIL3 = 'cod@gmail.com'
     USERNAME3 = 'cod'
     ESTIMATE3 = 1.0 * SECS_PER_DAY
-    DEPENDS3 = [KEY1, KEY2]
+    DEPENDS3 = [ID1, ID2]
 
     JIRA_JSON_ASSIGNEE_TEMPLATE = '''
             "assignee": {{
@@ -531,12 +534,12 @@ class TestJiraJuggler(unittest.TestCase):
 
         self.assertEqual(self.ASSIGNEE1, issues[2].properties['allocate'].value)
         self.assertEqual(self.ESTIMATE3 / self.SECS_PER_DAY, issues[2].properties['effort'].value)
-        self.assertEqual(f'    depends !{self.KEY1}, !{self.KEY2}\n', str(issues[2].properties['depends']))
+        self.assertEqual(f'    depends !{self.ID1}, !{self.ID2}\n', str(issues[2].properties['depends']))
 
         self.assertEqual('', str(issues[3].properties['depends']))
         self.assertEqual('    start 2021-08-23-13:00\n', str(issues[3].properties['time']))  # start on current date
 
-        self.assertEqual('    depends !Issue1, !Issue2\n', str(issues[4].properties['depends']))
+        self.assertEqual(f'    depends !{self.ID1}, !{self.ID2}\n', str(issues[4].properties['depends']))
         self.assertEqual('', str(issues[4].properties['time']))  # no start date as it depends on an unresolved task
 
     def _mock_jira_issue(self, key, summary, assignee='', estimates=[], depends=[], histories=[], status="Open", email=''):


### PR DESCRIPTION
Due to PR #25 a `KeyError` is raised when using the `-D, --depend-on-preceding` feature.