### PR TITLE
Support the Jira link with name 'Dependent'

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -22,9 +22,15 @@ jobs:
         python -m pip install tox tox-gh-actions
     - name: Run test
       run: tox -e py
-    - name: Codecov
+    - name: Upload coverage to Codecov
       if: matrix.python-version == 3.9
-      run: tox -e codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        fail_ci_if_error: true
+        flags: unittests
+        verbose: true
     - name: Static checks
       if: matrix.python-version == 3.9
       run: tox -e check
@@ -35,9 +41,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.7'
     - name: Install dependencies

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -355,7 +355,7 @@ class JugglerTaskDepends(JugglerTaskProperty):
             for link in jira_issue.fields.issuelinks:
                 if hasattr(link, 'inwardIssue') and link.type.name == 'Blocker':
                     self.append_value(to_identifier(link.inwardIssue.key))
-                if hasattr(link, 'outwardIssue') and link.type.name == 'Dependency':
+                if hasattr(link, 'outwardIssue') and link.type.name in ('Dependency', 'Dependent'):
                     self.append_value(to_identifier(link.outwardIssue.key))
 
     def validate(self, task, tasks):

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ basepython =
     py39: {env:TOXPYTHON:python3.9}
     py310: {env:TOXPYTHON:python3.10}
     py311: {env:TOXPYTHON:python3.11}
-    {clean,check,report,coveralls,codecov}: python3
+    {clean,check,report,coveralls}: python3
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -35,7 +35,7 @@ deps =
     pip>=20.3.4
     parameterized
 commands =
-    {posargs:py.test --cov --cov-report=term-missing -vv tests}
+    pytest --cov-report=term-missing --cov-report=xml -vv --cov tests
 
 [testenv:check]
 deps =
@@ -57,15 +57,6 @@ deps =
 skip_install = true
 commands =
     coveralls []
-
-[testenv:codecov]
-deps =
-    codecov
-skip_install = true
-commands =
-    coverage xml --ignore-errors
-    codecov []
-
 
 [testenv:report]
 deps = coverage


### PR DESCRIPTION
An update to Jira has renamed the link type 'Dependency' to 'Dependent'. 