### PR TITLE
Validate and add configurability for Jira issue link types; bug fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ setup(
         'write_to': 'src/mlx/__version__.py'
     },
     url=PROJECT_URL,
-    author='Stein Heselmans',
-    author_email='teh@melexis.com',
-    description='A python script for extracting data from Jira, and converting to task-juggler (tj3) output',
+    author='Jasper Craeghs',
+    author_email='jce@melexis.com',
+    description='A Python script for extracting data from Jira, and converting to TaskJuggler (tj3) output',
     long_description=open("README.rst").read(),
     long_description_content_type='text/x-rst',
     zip_safe=False,

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -385,9 +385,9 @@ class JugglerTaskDepends(JugglerTaskProperty):
         if hasattr(jira_issue.fields, 'issuelinks'):
             for link in jira_issue.fields.issuelinks:
                 if hasattr(link, 'inwardIssue') and link.type.inward in self.links:
-                   self.append_value(to_identifier(link.inwardIssue.key))
+                    self.append_value(to_identifier(link.inwardIssue.key))
                 elif hasattr(link, 'outwardIssue') and link.type.outward in self.links:
-                   self.append_value(to_identifier(link.outwardIssue.key))
+                    self.append_value(to_identifier(link.outwardIssue.key))
 
     def validate(self, task, tasks):
         """Validates (and corrects) the current task property
@@ -578,7 +578,6 @@ class JiraJuggler:
 
         all_jira_link_types = jirahandle.issue_link_types()
         JugglerTaskDepends.links = determine_links(all_jira_link_types, links)
-
 
     @staticmethod
     def validate_tasks(tasks):

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -366,8 +366,9 @@ class JugglerTaskDepends(JugglerTaskProperty):
             tasks (list): List of JugglerTask instances to which the current task belongs. Will be used to
                 verify relations to other tasks.
         """
-        for val in self.value:
-            if val not in [to_identifier(tsk.key) for tsk in tasks]:
+        task_ids = [to_identifier(tsk.key) for tsk in tasks]
+        for val in list(self.value):
+            if val not in task_ids:
                 logging.warning('Removing link to %s for %s, as not within scope', val, task.key)
                 self.value.remove(val)
 

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -489,18 +489,17 @@ task {id} "{description}" {{
         self.properties['depends'] = JugglerTaskDepends(jira_issue)
         self.properties['time'] = JugglerTaskTime()
 
-    def validate(self, tasks):
+    def validate(self, tasks, property_identifier):
         """Validates (and corrects) the current task
 
         Args:
             tasks (list): List of JugglerTask instances to which the current task belongs. Will be used to
                 verify relations to other tasks.
+            property_identifier (str): Identifier of property type
         """
         if self.key == self.DEFAULT_KEY:
             logging.error('Found a task which is not initialized')
-
-        for task_property in self.properties.values():
-            task_property.validate(self, tasks)
+        self.properties[property_identifier].validate(self, tasks)
 
     def __str__(self):
         """Converts the JugglerTask to the task juggler syntax
@@ -588,8 +587,9 @@ class JiraJuggler:
         Args:
             tasks (list): List of JugglerTask instances to validate
         """
-        for task in list(tasks):
-            task.validate(tasks)
+        for property_identifier in ('allocate', 'effort', 'depends', 'time'):
+            for task in list(tasks):
+                task.validate(tasks, property_identifier)
 
     def load_issues_from_jira(self, depend_on_preceding=False, sprint_field_name='', **kwargs):
         """Loads issues from Jira

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -373,7 +373,8 @@ class JugglerTaskDepends(JugglerTaskProperty):
         Args:
             value (object): Value to append to the property
         """
-        self.value.append(value)
+        if value not in self.value:
+            self.value.append(value)
 
     def load_from_jira_issue(self, jira_issue):
         """Loads the object with data from a Jira issue

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -353,20 +353,6 @@ class JugglerTaskDepends(JugglerTaskProperty):
     PREFIX = '!'
     links = set()
 
-    @property
-    def value(self):
-        """list: Value of the task juggler property"""
-        return self._value
-
-    @value.setter
-    def value(self, value):
-        """Sets value for task juggler property (deep copy)
-
-        Args:
-            value (object): New value of the property
-        """
-        self._value = list(value)
-
     def append_value(self, value):
         """Appends value for task juggler property
 
@@ -382,7 +368,7 @@ class JugglerTaskDepends(JugglerTaskProperty):
         Args:
             jira_issue (jira.resources.Issue): The Jira issue to load from
         """
-        self.value = self.DEFAULT_VALUE
+        self.value = list(self.DEFAULT_VALUE)
         if hasattr(jira_issue.fields, 'issuelinks'):
             for link in jira_issue.fields.issuelinks:
                 if hasattr(link, 'inwardIssue') and link.type.inward in self.links:

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -353,7 +353,7 @@ class JugglerTaskDepends(JugglerTaskProperty):
         self.value = self.DEFAULT_VALUE
         if hasattr(jira_issue.fields, 'issuelinks'):
             for link in jira_issue.fields.issuelinks:
-                if hasattr(link, 'inwardIssue') and link.type.name == 'Blocker':
+                if hasattr(link, 'inwardIssue') and link.type.name in ('Blocker', 'Blocks'):
                     self.append_value(to_identifier(link.inwardIssue.key))
                 if hasattr(link, 'outwardIssue') and link.type.name in ('Dependency', 'Dependent'):
                     self.append_value(to_identifier(link.outwardIssue.key))

--- a/src/mlx/jira_juggler.py
+++ b/src/mlx/jira_juggler.py
@@ -634,7 +634,7 @@ class JiraJuggler:
             time_property = task.properties['time']
 
             if task.is_resolved:
-                depends_property.clear()  # don't output any links in JIRA
+                depends_property.clear()  # don't output any links from JIRA
                 time_property.name = 'end'
                 time_property.value = task.resolved_at_repr
             else:

--- a/tests/test_jira_juggler.py
+++ b/tests/test_jira_juggler.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 from dateutil import parser
 from parameterized import parameterized
+from collections import namedtuple
 
 import unittest
 
@@ -31,6 +32,25 @@ except ImportError:
     import pip
     pip.main(['install', 'jira'])
     from jira import JIRA
+
+
+LinkType = namedtuple('LinkType', 'id name inward outward self')
+ISSUE_LINK_TYPES = [
+    LinkType(
+        id="1000",
+        name="Duplicate",
+        inward="is duplicated by",
+        outward="duplicates",
+        self="http://www.example.com/jira/rest/api/2//issueLinkType/1000",
+    ),
+    LinkType(
+        id="1010",
+        name="Blocker",
+        inward="is blocked by",
+        outward="blocks",
+        self="http://www.example.com/jira/rest/api/2//issueLinkType/1010",
+    ),
+]
 
 
 class TestJiraJuggler(unittest.TestCase):
@@ -112,7 +132,10 @@ class TestJiraJuggler(unittest.TestCase):
                         "key": "{depends}"
                     }},
                     "type": {{
-                        "name": "Blocker"
+                        "name": "Blocker",
+                        "id": "10031",
+                        "inward": "is blocked by",
+                        "outward": "blocks"
                     }}
                 }}
     '''
@@ -271,6 +294,7 @@ class TestJiraJuggler(unittest.TestCase):
         '''Test for removing a broken link to a dependant task'''
         jira_mock_object = MagicMock(spec=JIRA)
         jira_mock.return_value = jira_mock_object
+        jira_mock_object.issue_link_types.return_value = ISSUE_LINK_TYPES
         juggler = dut.JiraJuggler(self.URL, self.USER, self.PASSWD, self.QUERY)
         self.assertEqual(self.QUERY, juggler.query)
 
@@ -291,6 +315,7 @@ class TestJiraJuggler(unittest.TestCase):
         '''Test for dual happy flow: one task depends on the other'''
         jira_mock_object = MagicMock(spec=JIRA)
         jira_mock.return_value = jira_mock_object
+        jira_mock_object.issue_link_types.return_value = ISSUE_LINK_TYPES
         juggler = dut.JiraJuggler(self.URL, self.USER, self.PASSWD, self.QUERY)
         self.assertEqual(self.QUERY, juggler.query)
 
@@ -325,6 +350,7 @@ class TestJiraJuggler(unittest.TestCase):
         '''Test for extended happy flow: one task depends on two others'''
         jira_mock_object = MagicMock(spec=JIRA)
         jira_mock.return_value = jira_mock_object
+        jira_mock_object.issue_link_types.return_value = ISSUE_LINK_TYPES
         juggler = dut.JiraJuggler(self.URL, self.USER, self.PASSWD, self.QUERY)
         self.assertEqual(self.QUERY, juggler.query)
 
@@ -370,6 +396,7 @@ class TestJiraJuggler(unittest.TestCase):
         Test that the most recent transition to the Approved/Resolved state is used to mark the end'''
         jira_mock_object = MagicMock(spec=JIRA)
         jira_mock.return_value = jira_mock_object
+        jira_mock_object.issue_link_types.return_value = ISSUE_LINK_TYPES
         juggler = dut.JiraJuggler(self.URL, self.USER, self.PASSWD, self.QUERY)
         histories = [
             {
@@ -439,6 +466,7 @@ class TestJiraJuggler(unittest.TestCase):
         '''
         jira_mock_object = MagicMock(spec=JIRA)
         jira_mock.return_value = jira_mock_object
+        jira_mock_object.issue_link_types.return_value = ISSUE_LINK_TYPES
         juggler = dut.JiraJuggler(self.URL, self.USER, self.PASSWD, self.QUERY)
         histories = [
             {
@@ -476,6 +504,7 @@ class TestJiraJuggler(unittest.TestCase):
         '''Test --depends-on-preceding, --weeklymax and --current-date options'''
         jira_mock_object = MagicMock(spec=JIRA)
         jira_mock.return_value = jira_mock_object
+        jira_mock_object.issue_link_types.return_value = ISSUE_LINK_TYPES
         juggler = dut.JiraJuggler(self.URL, self.USER, self.PASSWD, self.QUERY)
         histories = [
             {

--- a/tests/test_jira_juggler.py
+++ b/tests/test_jira_juggler.py
@@ -50,6 +50,13 @@ ISSUE_LINK_TYPES = [
         outward="blocks",
         self="http://www.example.com/jira/rest/api/2//issueLinkType/1010",
     ),
+    LinkType(
+        id="1050",
+        name="Dependency",
+        inward="is dependency of",
+        outward="depends on",
+        self="http://www.example.com/jira/rest/api/2//issueLinkType/1050",
+    ),
 ]
 
 
@@ -133,7 +140,7 @@ class TestJiraJuggler(unittest.TestCase):
                     }},
                     "type": {{
                         "name": "Blocker",
-                        "id": "10031",
+                        "id": "1010",
                         "inward": "is blocked by",
                         "outward": "blocks"
                     }}


### PR DESCRIPTION
- Support link type `Blocks`, configured by Atlassian for Jira Cloud.
- Add input argument `[-L [LINKS ...]]` to override the default configuration of Jira issue link types to take into account for TaskJuggler's [`depends`](https://taskjuggler.org/tj3/manual/depends.html) keyword
- Validate existence of the aforementioned the configuration of Jira issue link types by retrieving all issue link types from the Jira instance
- Fix a rare and old bug that occurred when a task depends on two tasks with estimate of 0m successively, causing `KeyError` in `if not id_to_task_map[identifier].is_resolved:`
- Fix duplicate tasks for [`depends`](https://taskjuggler.org/tj3/manual/depends.html), resulting in an error by TaskJuggler: `Error in scenario plan: No need to specify dependency X multiple times for task Y.`


Closes #32 